### PR TITLE
standard Windows and Mac .gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,75 @@
+
+
+
+
+#########################################################################
+# Standard Windows .gitignore from:
+# https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
+#########################################################################
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+#########################################################################
+# Standard Mac .gitignore from:
+# https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
+#########################################################################
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+
+#########################################################################
+# Custom .gitignore rules specific to this repo:
+
+
+


### PR DESCRIPTION
so that if people new to git start contributing, this will help avoid them committing temporary files.